### PR TITLE
replacing Marshal with call to payload_coder

### DIFF
--- a/lib/tusk/observable/redis.rb
+++ b/lib/tusk/observable/redis.rb
@@ -102,7 +102,7 @@ module Tusk
       # observing objects.
       def notify_observers(*args)
         return unless changed?
-        connection.publish channel, Marshal.dump(args)
+        connection.publish channel, payload_coder.dump(args)
         changed false
       end
 


### PR DESCRIPTION
I'm such a doof, got all excited about pluggable payload
coders and then forgot to use it on the encoding side.
